### PR TITLE
Support abstr split

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,6 @@
+pre_release K. Leleux 04/23/26:
+    - adding new RF devices and setpoints to support abstraction layer
+      dual-energy split and new longitudinal SXR feedback
 R1.9.34 J. Lorelli,     02/28/2024
      - build against fcom R1.9.34
 

--- a/src/fcomUtil.c
+++ b/src/fcomUtil.c
@@ -70,10 +70,10 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 /* Used for parsing PV Names - NOTE Dependencies -                                             */
 /*                                                                                             */
 /************************************************************************************************/
-#define MAX_SETPOINTS  17   /* ensure count is compatible with setpoint_ca list count below !!! */
+#define MAX_SETPOINTS  22   /* ensure count is compatible with setpoint_ca list count below !!! */
 #define MAX_AREAS      31   /* ensure count is compatible with area_ca list count below !!!     */
 #define MAX_DEVTYPES    8   /* ensure count is compatible with devtype_ca list count below !!!  */
-#define MAX_RFNAMES    28   /* ensure count is compatible with rfname_ca list count below !!!   */
+#define MAX_RFNAMES    34   /* ensure count is compatible with rfname_ca list count below !!!   */
 /* Shantha Condamoor: 27-Feb-2014: increased detector list by 1 to add TCAV */
 #define MAX_DETECTOR_NAMES  3/* ensure count is compatible with detector_ca list count below !!!   */
 #define MAX_LOOP_TYPES  3   /* ensure count is compatible with looptype_ca list count below !!!   */
@@ -83,7 +83,8 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 /* list of setpoints - add future here [row] [col]; also update MAX_SETPOINTS above */
 static const char * setpoint_ca[MAX_SETPOINTS] = { "BCTRL", "L0A_PDES", "L0A_ADES", "L0B_PDES", "L0B_ADES", 
 		"TC0_PDES","TC0_ADES", "L1S_PDES", "L1S_ADES", "L1X_PDES", "L1X_ADES", "PDES", "ADES", 
-        "KLY_PDES","KLY_ADES", "TC3_PDES", "TC3_ADES", };
+        "KLY_PDES","KLY_ADES", "TC3_PDES", "TC3_ADES", "L0B_ADES2", "L1S_ADES2", "L1S_PDES2",
+        "PDES2", "ADES2"};
 
 /* list of areas  - add future here ; also update MAX_AREAS above      */
 static const char * area_ca[MAX_AREAS] = { "IN20", "LI21", "LI22", "LI23", "LI24", "LI25", "LI26", "LI27", "LI28", "LI29", "LI30",
@@ -102,7 +103,8 @@ static const char * rfname_ca[MAX_RFNAMES]= { "ACCL:IN20:300:L0A_PDES", "ACCL:IN
 		"ACCL:LI24:100:KLY_PDES", "ACCL:LI24:100:KLY_ADES", "ACCL:LI24:200:KLY_PDES","ACCL:LI24:200:KLY_ADES",  
 		"ACCL:LI24:300:KLY_PDES","ACCL:LI24:300:KLY_ADES","ACCL:LI29:0:KLY_PDES","ACCL:LI29:0:KLY_ADES",  
 		"ACCL:LI30:0:KLY_PDES", "ACCL:LI30:0:KLY_ADES","ACCL:LI22:1:PDES", "ACCL:LI22:1:ADES",
-                "ACCL:LI25:1:PDES", "ACCL:LI25:1:ADES"};
+        "ACCL:LI25:1:PDES", "ACCL:LI25:1:ADES", "ACCL:IN20:400:L0B_ADES2", "ACCL:LI21:1:L1S_ADES2",
+        "ACCL:LI21:1:L1S_PDES2", "ACCL:LI22:1:ADES2", "ACCL:LI22:1:PDES2", "ACCL:LI25:1:ADES2"};
 
 /* list of feedback loop types */
 static const char * looptype_ca[MAX_LOOP_TYPES] = {"TR", "LG", "GN" };

--- a/src/fcomUtil.c
+++ b/src/fcomUtil.c
@@ -70,10 +70,10 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 /* Used for parsing PV Names - NOTE Dependencies -                                             */
 /*                                                                                             */
 /************************************************************************************************/
-#define MAX_SETPOINTS  24   /* ensure count is compatible with setpoint_ca list count below !!! */
+#define MAX_SETPOINTS  32   /* ensure count is compatible with setpoint_ca list count below !!! */
 #define MAX_AREAS      31   /* ensure count is compatible with area_ca list count below !!!     */
 #define MAX_DEVTYPES    8   /* ensure count is compatible with devtype_ca list count below !!!  */
-#define MAX_RFNAMES    36   /* ensure count is compatible with rfname_ca list count below !!!   */
+#define MAX_RFNAMES    53   /* ensure count is compatible with rfname_ca list count below !!!   */
 /* Shantha Condamoor: 27-Feb-2014: increased detector list by 1 to add TCAV */
 #define MAX_DETECTOR_NAMES  3/* ensure count is compatible with detector_ca list count below !!!   */
 #define MAX_LOOP_TYPES  3   /* ensure count is compatible with looptype_ca list count below !!!   */
@@ -84,7 +84,8 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 static const char * setpoint_ca[MAX_SETPOINTS] = { "BCTRL", "L0A_PDES", "L0A_ADES", "L0B_PDES", "L0B_ADES", 
 		"TC0_PDES","TC0_ADES", "L1S_PDES", "L1S_ADES", "L1X_PDES", "L1X_ADES", "PDES", "ADES", 
         "KLY_PDES","KLY_ADES", "TC3_PDES", "TC3_ADES", "L0B_ADES2", "L1S_ADES2", "L1S_PDES2",
-        "PDES2", "ADES2", "TC0_PDES2", "TC0_ADES2"};
+        "PDES2", "ADES2", "TC0_PDES2", "TC0_ADES2", "L1X_ADES2", "L1X_PDES2", "L0A_ADES2",
+        "L0A_PDES2", "KLY_PDES2", "KLY_ADES2", "TC3_ADES2" ,"TC3_PDES2"};
 
 /* list of areas  - add future here ; also update MAX_AREAS above      */
 static const char * area_ca[MAX_AREAS] = { "IN20", "LI21", "LI22", "LI23", "LI24", "LI25", "LI26", "LI27", "LI28", "LI29", "LI30",
@@ -98,14 +99,18 @@ static const char * devtype_ca[MAX_DEVTYPES] = { "BPMS", "BLEN", "TCAV", "ACCL",
 /* list of RF names - order must match  */
 static const char * rfname_ca[MAX_RFNAMES]= { "ACCL:IN20:300:L0A_PDES", "ACCL:IN20:300:L0A_ADES", 
         "ACCL:IN20:400:L0B_PDES", "ACCL:IN20:400:L0B_ADES", "TCAV:IN20:490:TC0_PDES","TCAV:IN20:490:TC0_ADES", 
-		"ACCL:LI21:1:L1S_PDES","ACCL:LI21:1:L1S_ADES", "ACCL:LI21:180:L1X_PDES","ACCL:LI21:180:L1X_ADES",
+		"ACCL:LI21:1:L1S_PDES", "ACCL:LI21:1:L1S_ADES", "ACCL:LI21:180:L1X_PDES", "ACCL:LI21:180:L1X_ADES",
         "LLRF:IN20:RH:L2_PDES", "LLRF:IN20:RH:L2_ADES", "TCAV:LI24:800:TC3_PDES", "TCAV:LI24:800:TC3_ADES", 
-		"ACCL:LI24:100:KLY_PDES", "ACCL:LI24:100:KLY_ADES", "ACCL:LI24:200:KLY_PDES","ACCL:LI24:200:KLY_ADES",  
-		"ACCL:LI24:300:KLY_PDES","ACCL:LI24:300:KLY_ADES","ACCL:LI29:0:KLY_PDES","ACCL:LI29:0:KLY_ADES",  
+		"ACCL:LI24:100:KLY_PDES", "ACCL:LI24:100:KLY_ADES", "ACCL:LI24:200:KLY_PDES", "ACCL:LI24:200:KLY_ADES",  
+		"ACCL:LI24:300:KLY_PDES", "ACCL:LI24:300:KLY_ADES", "ACCL:LI29:0:KLY_PDES", "ACCL:LI29:0:KLY_ADES",  
 		"ACCL:LI30:0:KLY_PDES", "ACCL:LI30:0:KLY_ADES","ACCL:LI22:1:PDES", "ACCL:LI22:1:ADES",
-        "ACCL:LI25:1:PDES", "ACCL:LI25:1:ADES", "ACCL:IN20:400:L0B_ADES2", "ACCL:LI21:1:L1S_ADES2",
+        "ACCL:LI25:1:PDES", "ACCL:LI25:1:ADES", "ACCL:IN20:400:L0B_ADES2", "ACCL:IN20:400:L0B_PDES2", "ACCL:LI21:1:L1S_ADES2",
         "ACCL:LI21:1:L1S_PDES2", "ACCL:LI22:1:ADES2", "ACCL:LI22:1:PDES2", "ACCL:LI25:1:ADES2",
-        "TCAV:IN20:490:TC0_PDES2", "TCAV:IN20:490:TC0_ADES2"};
+        "TCAV:IN20:490:TC0_PDES2", "TCAV:IN20:490:TC0_ADES2", "ACCL:LI21:180:L1X_ADES2", "ACCL:LI21:180:L1X_PDES2",
+        "ACCL:IN20:300:L0A_ADES2", "ACCL:IN20:300:L0A_PDES2", "ACCL:LI24:100:KLY_PDES2", "ACCL:LI24:200:KLY_PDES2",
+        "ACCL:LI24:300:KLY_PDES2", "ACCL:LI29:0:KLY_PDES2", "ACCL:LI30:0:KLY_PDES2", "TCAV:LI24:800:TC3_PDES2", 
+        "TCAV:LI24:800:TC3_ADES2", "ACCL:LI24:100:KLY_ADES2", "ACCL:LI24:200:KLY_ADES2", "ACCL:LI24:300:KLY_ADES2", 
+        "ACCL:LI29:0:KLY_ADES2", "ACCL:LI30:0:KLY_ADES2"};
 
 /* list of feedback loop types */
 static const char * looptype_ca[MAX_LOOP_TYPES] = {"TR", "LG", "GN" };

--- a/src/fcomUtil.c
+++ b/src/fcomUtil.c
@@ -70,10 +70,10 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 /* Used for parsing PV Names - NOTE Dependencies -                                             */
 /*                                                                                             */
 /************************************************************************************************/
-#define MAX_SETPOINTS  22   /* ensure count is compatible with setpoint_ca list count below !!! */
+#define MAX_SETPOINTS  24   /* ensure count is compatible with setpoint_ca list count below !!! */
 #define MAX_AREAS      31   /* ensure count is compatible with area_ca list count below !!!     */
 #define MAX_DEVTYPES    8   /* ensure count is compatible with devtype_ca list count below !!!  */
-#define MAX_RFNAMES    34   /* ensure count is compatible with rfname_ca list count below !!!   */
+#define MAX_RFNAMES    36   /* ensure count is compatible with rfname_ca list count below !!!   */
 /* Shantha Condamoor: 27-Feb-2014: increased detector list by 1 to add TCAV */
 #define MAX_DETECTOR_NAMES  3/* ensure count is compatible with detector_ca list count below !!!   */
 #define MAX_LOOP_TYPES  3   /* ensure count is compatible with looptype_ca list count below !!!   */
@@ -84,7 +84,7 @@ static char * fcomStrtok_r(char *s1, const char *s2, char **lasts);
 static const char * setpoint_ca[MAX_SETPOINTS] = { "BCTRL", "L0A_PDES", "L0A_ADES", "L0B_PDES", "L0B_ADES", 
 		"TC0_PDES","TC0_ADES", "L1S_PDES", "L1S_ADES", "L1X_PDES", "L1X_ADES", "PDES", "ADES", 
         "KLY_PDES","KLY_ADES", "TC3_PDES", "TC3_ADES", "L0B_ADES2", "L1S_ADES2", "L1S_PDES2",
-        "PDES2", "ADES2"};
+        "PDES2", "ADES2", "TC0_PDES2", "TC0_ADES2"};
 
 /* list of areas  - add future here ; also update MAX_AREAS above      */
 static const char * area_ca[MAX_AREAS] = { "IN20", "LI21", "LI22", "LI23", "LI24", "LI25", "LI26", "LI27", "LI28", "LI29", "LI30",
@@ -104,7 +104,8 @@ static const char * rfname_ca[MAX_RFNAMES]= { "ACCL:IN20:300:L0A_PDES", "ACCL:IN
 		"ACCL:LI24:300:KLY_PDES","ACCL:LI24:300:KLY_ADES","ACCL:LI29:0:KLY_PDES","ACCL:LI29:0:KLY_ADES",  
 		"ACCL:LI30:0:KLY_PDES", "ACCL:LI30:0:KLY_ADES","ACCL:LI22:1:PDES", "ACCL:LI22:1:ADES",
         "ACCL:LI25:1:PDES", "ACCL:LI25:1:ADES", "ACCL:IN20:400:L0B_ADES2", "ACCL:LI21:1:L1S_ADES2",
-        "ACCL:LI21:1:L1S_PDES2", "ACCL:LI22:1:ADES2", "ACCL:LI22:1:PDES2", "ACCL:LI25:1:ADES2"};
+        "ACCL:LI21:1:L1S_PDES2", "ACCL:LI22:1:ADES2", "ACCL:LI22:1:PDES2", "ACCL:LI25:1:ADES2",
+        "TCAV:IN20:490:TC0_PDES2", "TCAV:IN20:490:TC0_ADES2"};
 
 /* list of feedback loop types */
 static const char * looptype_ca[MAX_LOOP_TYPES] = {"TR", "LG", "GN" };


### PR DESCRIPTION
Lots of work has been done to support the dual-energy split of the abstraction layer. Part of this work includes a new SXR longitudinal feedback, which will use new SXR pvs which append "2" to the end of existing rf devices. I have also added TCAV0 SXR parameters to reflect that this was also upgraded to support dual-energy. 